### PR TITLE
Revert "renombrado de paquetes I"

### DIFF
--- a/Censuses/src/main/java/es/uniovi/asw/dBUpdate/Insert.java
+++ b/Censuses/src/main/java/es/uniovi/asw/dBUpdate/Insert.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.dbupdate;
+package es.uniovi.asw.dBUpdate;
 
 import java.util.List;
 

--- a/Censuses/src/main/java/es/uniovi/asw/dBUpdate/InsertP.java
+++ b/Censuses/src/main/java/es/uniovi/asw/dBUpdate/InsertP.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.dbupdate;
+package es.uniovi.asw.dBUpdate;
 
 import java.util.List;
 
@@ -8,11 +8,11 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.orm.jpa.EntityScan;
 import org.springframework.context.annotation.Bean;
 
-import es.uniovi.asw.dbupdate.validate.Validation;
+import es.uniovi.asw.dBUpdate.validate.Validation;
 import es.uniovi.asw.model.Voter;
 import es.uniovi.asw.parser.letter.GenerarateLetter;
 import es.uniovi.asw.parser.password.Encryptation;
-import es.uniovi.asw.reportwriter.WreportR;
+import es.uniovi.asw.reportWriter.WreportR;
 
 /**
  * Clase que verifica los datos y genera el LOG con los datos inconsistentes

--- a/Censuses/src/main/java/es/uniovi/asw/dBUpdate/PollingStationRepository.java
+++ b/Censuses/src/main/java/es/uniovi/asw/dBUpdate/PollingStationRepository.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.dbupdate;
+package es.uniovi.asw.dBUpdate;
 
 import java.util.List;
 

--- a/Censuses/src/main/java/es/uniovi/asw/dBUpdate/VoterRepository.java
+++ b/Censuses/src/main/java/es/uniovi/asw/dBUpdate/VoterRepository.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.dbupdate;
+package es.uniovi.asw.dBUpdate;
 
 import org.springframework.data.repository.CrudRepository;
 

--- a/Censuses/src/main/java/es/uniovi/asw/dBUpdate/validate/DuplicateFieldValidation.java
+++ b/Censuses/src/main/java/es/uniovi/asw/dBUpdate/validate/DuplicateFieldValidation.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.dbupdate.validate;
+package es.uniovi.asw.dBUpdate.validate;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/Censuses/src/main/java/es/uniovi/asw/dBUpdate/validate/EmailFieldValidation.java
+++ b/Censuses/src/main/java/es/uniovi/asw/dBUpdate/validate/EmailFieldValidation.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.dbupdate.validate;
+package es.uniovi.asw.dBUpdate.validate;
 
 import es.uniovi.asw.model.Voter;
 

--- a/Censuses/src/main/java/es/uniovi/asw/dBUpdate/validate/EmptyFieldValidation.java
+++ b/Censuses/src/main/java/es/uniovi/asw/dBUpdate/validate/EmptyFieldValidation.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.dbupdate.validate;
+package es.uniovi.asw.dBUpdate.validate;
 
 import es.uniovi.asw.model.Voter;
 

--- a/Censuses/src/main/java/es/uniovi/asw/dBUpdate/validate/NIFFieldValidation.java
+++ b/Censuses/src/main/java/es/uniovi/asw/dBUpdate/validate/NIFFieldValidation.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.dbupdate.validate;
+package es.uniovi.asw.dBUpdate.validate;
 
 import es.uniovi.asw.model.Voter;
 

--- a/Censuses/src/main/java/es/uniovi/asw/dBUpdate/validate/StringFormatValidation.java
+++ b/Censuses/src/main/java/es/uniovi/asw/dBUpdate/validate/StringFormatValidation.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.dbupdate.validate;
+package es.uniovi.asw.dBUpdate.validate;
 
 import es.uniovi.asw.model.Voter;
 

--- a/Censuses/src/main/java/es/uniovi/asw/dBUpdate/validate/Validate.java
+++ b/Censuses/src/main/java/es/uniovi/asw/dBUpdate/validate/Validate.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.dbupdate.validate;
+package es.uniovi.asw.dBUpdate.validate;
 
 import es.uniovi.asw.model.Voter;
 

--- a/Censuses/src/main/java/es/uniovi/asw/dBUpdate/validate/Validation.java
+++ b/Censuses/src/main/java/es/uniovi/asw/dBUpdate/validate/Validation.java
@@ -1,10 +1,10 @@
-package es.uniovi.asw.dbupdate.validate;
+package es.uniovi.asw.dBUpdate.validate;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import es.uniovi.asw.model.Voter;
-import es.uniovi.asw.reportwriter.WreportR;
+import es.uniovi.asw.reportWriter.WreportR;
 
 /**
  * Clase aplica todas las validaciones necesarias sobre los distintos campos de

--- a/Censuses/src/main/java/es/uniovi/asw/parser/InsertR.java
+++ b/Censuses/src/main/java/es/uniovi/asw/parser/InsertR.java
@@ -3,7 +3,7 @@ package es.uniovi.asw.parser;
 import java.io.IOException;
 import java.util.List;
 
-import es.uniovi.asw.dbupdate.InsertP;
+import es.uniovi.asw.dBUpdate.InsertP;
 import es.uniovi.asw.model.Voter;
 import es.uniovi.asw.parser.password.GenerarClave;
 

--- a/Censuses/src/main/java/es/uniovi/asw/parser/LoadFromExcel.java
+++ b/Censuses/src/main/java/es/uniovi/asw/parser/LoadFromExcel.java
@@ -16,7 +16,7 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 import es.uniovi.asw.model.ColegioElectoral;
 import es.uniovi.asw.model.Voter;
-import es.uniovi.asw.reportwriter.WreportR;
+import es.uniovi.asw.reportWriter.WreportR;
 
 /**
  * Clase que permite cargar los datos de los votantes de un fichero Excel

--- a/Censuses/src/main/java/es/uniovi/asw/parser/LoadFromTxt.java
+++ b/Censuses/src/main/java/es/uniovi/asw/parser/LoadFromTxt.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 import es.uniovi.asw.model.ColegioElectoral;
 import es.uniovi.asw.model.Voter;
-import es.uniovi.asw.reportwriter.WreportR;
+import es.uniovi.asw.reportWriter.WreportR;
 
 /**
  * Clase que permite cargar los datos de los votantes de un fichero TXT

--- a/Censuses/src/main/java/es/uniovi/asw/reportWriter/WreportP.java
+++ b/Censuses/src/main/java/es/uniovi/asw/reportWriter/WreportP.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.reportwriter;
+package es.uniovi.asw.reportWriter;
 
 import java.sql.Date;
 import java.text.DateFormat;

--- a/Censuses/src/main/java/es/uniovi/asw/reportWriter/WreportR.java
+++ b/Censuses/src/main/java/es/uniovi/asw/reportWriter/WreportR.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.reportwriter;
+package es.uniovi.asw.reportWriter;
 
 import java.io.BufferedWriter;
 import java.io.FileWriter;

--- a/Censuses/src/main/java/es/uniovi/asw/reportWriter/WriteReport.java
+++ b/Censuses/src/main/java/es/uniovi/asw/reportWriter/WriteReport.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.reportwriter;
+package es.uniovi.asw.reportWriter;
 
 /**
  * Interfaz que define los servicios de LOG

--- a/Censuses/src/test/java/es/uniovi/asw/LoadUsersTest.java
+++ b/Censuses/src/test/java/es/uniovi/asw/LoadUsersTest.java
@@ -1,7 +1,6 @@
 package es.uniovi.asw;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.util.List;

--- a/Censuses/src/test/java/es/uniovi/asw/ValidationTest.java
+++ b/Censuses/src/test/java/es/uniovi/asw/ValidationTest.java
@@ -1,13 +1,13 @@
 package es.uniovi.asw;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import org.junit.Before;
 import org.junit.Test;
 
-import es.uniovi.asw.dbupdate.validate.DuplicateFieldValidation;
-import es.uniovi.asw.dbupdate.validate.EmailFieldValidation;
-import es.uniovi.asw.dbupdate.validate.EmptyFieldValidation;
+import es.uniovi.asw.dBUpdate.validate.DuplicateFieldValidation;
+import es.uniovi.asw.dBUpdate.validate.EmailFieldValidation;
+import es.uniovi.asw.dBUpdate.validate.EmptyFieldValidation;
 import es.uniovi.asw.model.Voter;
 
 public class ValidationTest {

--- a/VotingSystem/src/main/java/es/uniovi/asw/VoteCounting/recuento/CountSystemFactory.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VoteCounting/recuento/CountSystemFactory.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 import es.uniovi.asw.VoteCounting.recuento.impl.StdCountSystem;
-import es.uniovi.asw.dbmanagement.Persistence;
+import es.uniovi.asw.dbManagement.Persistence;
 import es.uniovi.asw.model.Eleccion;
 
 @Component

--- a/VotingSystem/src/main/java/es/uniovi/asw/VoteCounting/recuento/impl/BeanListaVotaciones.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VoteCounting/recuento/impl/BeanListaVotaciones.java
@@ -7,7 +7,7 @@ import javax.annotation.PostConstruct;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
-import es.uniovi.asw.dbmanagement.Persistence;
+import es.uniovi.asw.dbManagement.Persistence;
 import es.uniovi.asw.model.Eleccion;
 
 @Component

--- a/VotingSystem/src/main/java/es/uniovi/asw/VoteCounting/recuento/impl/StdCountSystem.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VoteCounting/recuento/impl/StdCountSystem.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import es.uniovi.asw.VoteCounting.recuento.CountSystem;
-import es.uniovi.asw.dbmanagement.Persistence;
+import es.uniovi.asw.dbManagement.Persistence;
 import es.uniovi.asw.model.Candidatura;
 import es.uniovi.asw.model.ColegioElectoral;
 import es.uniovi.asw.model.ComunidadAutonoma;

--- a/VotingSystem/src/main/java/es/uniovi/asw/Voters/exceptions/UserNotFoundException.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/Voters/exceptions/UserNotFoundException.java
@@ -1,9 +1,9 @@
-package es.uniovi.asw.voters.exceptions;
+package es.uniovi.asw.Voters.exceptions;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-import es.uniovi.asw.voters.types.UserPass;
+import es.uniovi.asw.Voters.types.UserPass;
 
 // No usado actualmente
 @ResponseStatus(HttpStatus.NOT_FOUND)

--- a/VotingSystem/src/main/java/es/uniovi/asw/Voters/types/ChangePass.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/Voters/types/ChangePass.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.voters.types;
+package es.uniovi.asw.Voters.types;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;

--- a/VotingSystem/src/main/java/es/uniovi/asw/Voters/types/Encrypter.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/Voters/types/Encrypter.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.voters.types;
+package es.uniovi.asw.Voters.types;
 
 import java.security.MessageDigest;
 import java.util.Arrays;

--- a/VotingSystem/src/main/java/es/uniovi/asw/Voters/types/UserInfo.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/Voters/types/UserInfo.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.voters.types;
+package es.uniovi.asw.Voters.types;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;

--- a/VotingSystem/src/main/java/es/uniovi/asw/Voters/types/UserPass.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/Voters/types/UserPass.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.voters.types;
+package es.uniovi.asw.Voters.types;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;

--- a/VotingSystem/src/main/java/es/uniovi/asw/Voters/voterAccess/MainController.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/Voters/voterAccess/MainController.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.voters.voterAccess;
+package es.uniovi.asw.Voters.voterAccess;
 
 import javax.validation.Valid;
 
@@ -11,11 +11,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
-import es.uniovi.asw.dbmanagement.Persistence;
+import es.uniovi.asw.Voters.types.ChangePass;
+import es.uniovi.asw.Voters.types.UserInfo;
+import es.uniovi.asw.Voters.types.UserPass;
+import es.uniovi.asw.dbManagement.Persistence;
 import es.uniovi.asw.model.Voter;
-import es.uniovi.asw.voters.types.ChangePass;
-import es.uniovi.asw.voters.types.UserInfo;
-import es.uniovi.asw.voters.types.UserPass;
 
 @Controller
 @RestController

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/login/Authenticate.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/login/Authenticate.java
@@ -1,7 +1,7 @@
-package es.uniovi.asw.votingSystem.business.login;
+package es.uniovi.asw.VotingSystem.business.login;
 
-import es.uniovi.asw.dbmanagement.Persistence;
-import es.uniovi.asw.dbmanagement.VoterRepository;
+import es.uniovi.asw.dbManagement.Persistence;
+import es.uniovi.asw.dbManagement.VoterRepository;
 import es.uniovi.asw.model.Voter;
 
 public class Authenticate {

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/login/Logout.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/login/Logout.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.votingSystem.business.login;
+package es.uniovi.asw.VotingSystem.business.login;
 
 public class Logout {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/registerVote/storePhisicalVoteManagement/AddPhysicalVote.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/registerVote/storePhisicalVoteManagement/AddPhysicalVote.java
@@ -1,8 +1,8 @@
-package es.uniovi.asw.votingSystem.business.registerVote.storePhisicalVoteManagement;
+package es.uniovi.asw.VotingSystem.business.registerVote.storePhisicalVoteManagement;
 
-import es.uniovi.asw.dbmanagement.ConfirmedVoteRepository;
-import es.uniovi.asw.dbmanagement.VoterRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.dbManagement.ConfirmedVoteRepository;
+import es.uniovi.asw.dbManagement.VoterRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 
 public interface AddPhysicalVote {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/registerVote/storePhisicalVoteManagement/CheckVote.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/registerVote/storePhisicalVoteManagement/CheckVote.java
@@ -1,6 +1,6 @@
-package es.uniovi.asw.votingSystem.business.registerVote.storePhisicalVoteManagement;
+package es.uniovi.asw.VotingSystem.business.registerVote.storePhisicalVoteManagement;
 
-import es.uniovi.asw.dbmanagement.ConfirmedVoteRepository;
+import es.uniovi.asw.dbManagement.ConfirmedVoteRepository;
 
 public interface CheckVote {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/registerVote/storePhisicalVoteManagement/GetActiveVotings.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/registerVote/storePhisicalVoteManagement/GetActiveVotings.java
@@ -1,7 +1,7 @@
-package es.uniovi.asw.votingSystem.business.registerVote.storePhisicalVoteManagement;
+package es.uniovi.asw.VotingSystem.business.registerVote.storePhisicalVoteManagement;
 
-import es.uniovi.asw.dbmanagement.VotingRepository;
 import es.uniovi.asw.model.Eleccion;
+import es.uniovi.asw.dbManagement.VotingRepository;
 
 public interface GetActiveVotings {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/registerVote/storePhisicalVoteManagement/GetVoters.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/registerVote/storePhisicalVoteManagement/GetVoters.java
@@ -1,9 +1,9 @@
-package es.uniovi.asw.votingSystem.business.registerVote.storePhisicalVoteManagement;
+package es.uniovi.asw.VotingSystem.business.registerVote.storePhisicalVoteManagement;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.VoterRepository;
 import es.uniovi.asw.model.Voter;
+import es.uniovi.asw.dbManagement.VoterRepository;
 
 public interface GetVoters {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/registerVote/storePhisicalVoteManagement/PhysicalVoteService.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/registerVote/storePhisicalVoteManagement/PhysicalVoteService.java
@@ -1,12 +1,12 @@
-package es.uniovi.asw.votingSystem.business.registerVote.storePhisicalVoteManagement;
+package es.uniovi.asw.VotingSystem.business.registerVote.storePhisicalVoteManagement;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.ConfirmedVoteRepository;
-import es.uniovi.asw.dbmanagement.VoterRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
 import es.uniovi.asw.model.Eleccion;
 import es.uniovi.asw.model.Voter;
+import es.uniovi.asw.dbManagement.ConfirmedVoteRepository;
+import es.uniovi.asw.dbManagement.VoterRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 
 public interface PhysicalVoteService {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/registerVote/storePhisicalVoteManagement/impl/AddPhysicalVoteImpl.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/registerVote/storePhisicalVoteManagement/impl/AddPhysicalVoteImpl.java
@@ -1,16 +1,14 @@
-package es.uniovi.asw.votingSystem.business.registerVote.storePhisicalVoteManagement.impl;
+package es.uniovi.asw.VotingSystem.business.registerVote.storePhisicalVoteManagement.impl;
 
-//import es.uniovi.asw.VotingSystem.business.registerVote.storePhisicalVoteManagement.AddPhysicalVote;
-//import es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement.AddVote;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement.impl.PersistenceFactory;
-import es.uniovi.asw.dbmanagement.ConfirmedVoteRepository;
-import es.uniovi.asw.dbmanagement.VoterRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.VotingSystem.business.registerVote.storePhisicalVoteManagement.AddPhysicalVote;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement.AddVote;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement.impl.PersistenceFactory;
+import es.uniovi.asw.dbManagement.ConfirmedVoteRepository;
+import es.uniovi.asw.dbManagement.VoterRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Eleccion;
 import es.uniovi.asw.model.Voter;
 import es.uniovi.asw.model.VotoConfirmado;
-import es.uniovi.asw.votingSystem.business.registerVote.storePhisicalVoteManagement.AddPhysicalVote;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement.AddVote;
 
 public class AddPhysicalVoteImpl implements AddPhysicalVote {
 
@@ -32,5 +30,4 @@ public class AddPhysicalVoteImpl implements AddPhysicalVote {
 
 		return true;
 	}
-
 }

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/registerVote/storePhisicalVoteManagement/impl/CheckVoteImpl.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/registerVote/storePhisicalVoteManagement/impl/CheckVoteImpl.java
@@ -1,8 +1,8 @@
-package es.uniovi.asw.votingSystem.business.registerVote.storePhisicalVoteManagement.impl;
+package es.uniovi.asw.VotingSystem.business.registerVote.storePhisicalVoteManagement.impl;
 
-import es.uniovi.asw.votingSystem.business.registerVote.storePhisicalVoteManagement.CheckVote;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement.impl.PersistenceFactory;
-import es.uniovi.asw.dbmanagement.ConfirmedVoteRepository;
+import es.uniovi.asw.VotingSystem.business.registerVote.storePhisicalVoteManagement.CheckVote;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement.impl.PersistenceFactory;
+import es.uniovi.asw.dbManagement.ConfirmedVoteRepository;
 
 public class CheckVoteImpl implements CheckVote {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/registerVote/storePhisicalVoteManagement/impl/GetActiveVotingsImpl.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/registerVote/storePhisicalVoteManagement/impl/GetActiveVotingsImpl.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.votingSystem.business.registerVote.storePhisicalVoteManagement.impl;
+package es.uniovi.asw.VotingSystem.business.registerVote.storePhisicalVoteManagement.impl;
 
 import java.util.Date;
 
@@ -6,9 +6,9 @@ import java.util.ArrayList;
 
 import java.util.List;
 
-import es.uniovi.asw.votingSystem.business.registerVote.storePhisicalVoteManagement.GetActiveVotings;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement.impl.PersistenceFactory;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.VotingSystem.business.registerVote.storePhisicalVoteManagement.GetActiveVotings;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement.impl.PersistenceFactory;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Eleccion;
 
 public class GetActiveVotingsImpl implements GetActiveVotings {

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/registerVote/storePhisicalVoteManagement/impl/GetVotersImpl.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/registerVote/storePhisicalVoteManagement/impl/GetVotersImpl.java
@@ -1,8 +1,8 @@
-package es.uniovi.asw.votingSystem.business.registerVote.storePhisicalVoteManagement.impl;
+package es.uniovi.asw.VotingSystem.business.registerVote.storePhisicalVoteManagement.impl;
 
-import es.uniovi.asw.votingSystem.business.registerVote.storePhisicalVoteManagement.GetVoters;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement.impl.PersistenceFactory;
-import es.uniovi.asw.dbmanagement.VoterRepository;
+import es.uniovi.asw.VotingSystem.business.registerVote.storePhisicalVoteManagement.GetVoters;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement.impl.PersistenceFactory;
+import es.uniovi.asw.dbManagement.VoterRepository;
 import es.uniovi.asw.model.Voter;
 import java.util.List;
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/registerVote/storePhisicalVoteManagement/impl/PhysicalVoteServiceImpl.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/registerVote/storePhisicalVoteManagement/impl/PhysicalVoteServiceImpl.java
@@ -1,13 +1,13 @@
-package es.uniovi.asw.votingSystem.business.registerVote.storePhisicalVoteManagement.impl;
+package es.uniovi.asw.VotingSystem.business.registerVote.storePhisicalVoteManagement.impl;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.ConfirmedVoteRepository;
-import es.uniovi.asw.dbmanagement.VoterRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.VotingSystem.business.registerVote.storePhisicalVoteManagement.PhysicalVoteService;
+import es.uniovi.asw.dbManagement.ConfirmedVoteRepository;
+import es.uniovi.asw.dbManagement.VoterRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Eleccion;
 import es.uniovi.asw.model.Voter;
-import es.uniovi.asw.votingSystem.business.registerVote.storePhisicalVoteManagement.PhysicalVoteService;
 
 public class PhysicalVoteServiceImpl implements PhysicalVoteService {
 	private static PhysicalVoteServiceImpl ourInstance = new PhysicalVoteServiceImpl();

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/systemConfiguration/votingParamsManagement/SysConfigServiceFactory.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/systemConfiguration/votingParamsManagement/SysConfigServiceFactory.java
@@ -1,11 +1,11 @@
-package es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement;
+package es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement;
 
-import es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.candidacyManagement.CandidacyService;
-import es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.candidacyManagement.CandidacyServiceImpl;
-import es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.pollingStationManagement.PollingStationService;
-import es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.pollingStationManagement.PollingStationServiceImpl;
-import es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.voting.VotingTypeService;
-import es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.voting.VotingTypeServiceImpl;
+import es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.candidacyManagement.CandidacyService;
+import es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.candidacyManagement.CandidacyServiceImpl;
+import es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.pollingStationManagement.PollingStationService;
+import es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.pollingStationManagement.PollingStationServiceImpl;
+import es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.voting.VotingTypeService;
+import es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.voting.VotingTypeServiceImpl;
 
 public class SysConfigServiceFactory {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/systemConfiguration/votingParamsManagement/candidacyManagement/CandidacyService.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/systemConfiguration/votingParamsManagement/candidacyManagement/CandidacyService.java
@@ -1,9 +1,9 @@
-package es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.candidacyManagement;
+package es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.candidacyManagement;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.CandidacyRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.dbManagement.CandidacyRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Candidatura;
 
 public interface CandidacyService {

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/systemConfiguration/votingParamsManagement/candidacyManagement/CandidacyServiceImpl.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/systemConfiguration/votingParamsManagement/candidacyManagement/CandidacyServiceImpl.java
@@ -1,9 +1,9 @@
-package es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.candidacyManagement;
+package es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.candidacyManagement;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.CandidacyRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.dbManagement.CandidacyRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Candidatura;
 
 public class CandidacyServiceImpl implements CandidacyService {

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/systemConfiguration/votingParamsManagement/candidacyManagement/ConfCandidacy.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/systemConfiguration/votingParamsManagement/candidacyManagement/ConfCandidacy.java
@@ -1,11 +1,11 @@
-package es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.candidacyManagement;
+package es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.candidacyManagement;
 
 import java.util.List;
 
-import es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.AddCandidacyC;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.impl.PersistenceFactory;
-import es.uniovi.asw.dbmanagement.CandidacyRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.AddCandidacyC;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.impl.PersistenceFactory;
+import es.uniovi.asw.dbManagement.CandidacyRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Candidatura;
 
 class ConfCandidacy {

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/systemConfiguration/votingParamsManagement/candidacyManagement/GetCandidacys.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/systemConfiguration/votingParamsManagement/candidacyManagement/GetCandidacys.java
@@ -1,11 +1,11 @@
-package es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.candidacyManagement;
+package es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.candidacyManagement;
 
 import java.util.List;
 
-import es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.GetCandidacyS;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.impl.PersistenceFactory;
-import es.uniovi.asw.dbmanagement.CandidacyRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.GetCandidacyS;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.impl.PersistenceFactory;
+import es.uniovi.asw.dbManagement.CandidacyRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Candidatura;
 
 class GetCandidacys {

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/systemConfiguration/votingParamsManagement/pollingStationManagement/ConfPollingStation.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/systemConfiguration/votingParamsManagement/pollingStationManagement/ConfPollingStation.java
@@ -1,8 +1,8 @@
-package es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.pollingStationManagement;
+package es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.pollingStationManagement;
 
-import es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.AddPollingStation;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.impl.PersistenceFactory;
-import es.uniovi.asw.dbmanagement.PollingStationRepository;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.AddPollingStation;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.impl.PersistenceFactory;
+import es.uniovi.asw.dbManagement.PollingStationRepository;
 import es.uniovi.asw.model.ColegioElectoral;
 
 class ConfPollingStation {

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/systemConfiguration/votingParamsManagement/pollingStationManagement/GetPollingStations.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/systemConfiguration/votingParamsManagement/pollingStationManagement/GetPollingStations.java
@@ -1,11 +1,11 @@
-package es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.pollingStationManagement;
+package es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.pollingStationManagement;
 
 import java.util.List;
 
-import es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.GetPollingStationsP;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.impl.PersistenceFactory;
-import es.uniovi.asw.dbmanagement.CircumscriptionRepository;
-import es.uniovi.asw.dbmanagement.PollingStationRepository;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.GetPollingStationsP;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.impl.PersistenceFactory;
+import es.uniovi.asw.dbManagement.CircumscriptionRepository;
+import es.uniovi.asw.dbManagement.PollingStationRepository;
 import es.uniovi.asw.model.Circunscripcion;
 import es.uniovi.asw.model.ColegioElectoral;
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/systemConfiguration/votingParamsManagement/pollingStationManagement/PollingStationService.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/systemConfiguration/votingParamsManagement/pollingStationManagement/PollingStationService.java
@@ -1,9 +1,9 @@
-package es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.pollingStationManagement;
+package es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.pollingStationManagement;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.CircumscriptionRepository;
-import es.uniovi.asw.dbmanagement.PollingStationRepository;
+import es.uniovi.asw.dbManagement.CircumscriptionRepository;
+import es.uniovi.asw.dbManagement.PollingStationRepository;
 import es.uniovi.asw.model.Circunscripcion;
 import es.uniovi.asw.model.ColegioElectoral;
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/systemConfiguration/votingParamsManagement/pollingStationManagement/PollingStationServiceImpl.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/systemConfiguration/votingParamsManagement/pollingStationManagement/PollingStationServiceImpl.java
@@ -1,9 +1,9 @@
-package es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.pollingStationManagement;
+package es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.pollingStationManagement;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.CircumscriptionRepository;
-import es.uniovi.asw.dbmanagement.PollingStationRepository;
+import es.uniovi.asw.dbManagement.CircumscriptionRepository;
+import es.uniovi.asw.dbManagement.PollingStationRepository;
 import es.uniovi.asw.model.Circunscripcion;
 import es.uniovi.asw.model.ColegioElectoral;
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/systemConfiguration/votingParamsManagement/voting/ConfVotingType.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/systemConfiguration/votingParamsManagement/voting/ConfVotingType.java
@@ -1,9 +1,9 @@
-package es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.voting;
+package es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.voting;
 
-import es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.AddVotingType;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.impl.PersistenceFactory;
-import es.uniovi.asw.dbmanagement.CandidacyRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.AddVotingType;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.impl.PersistenceFactory;
+import es.uniovi.asw.dbManagement.CandidacyRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Eleccion;
 
 class ConfVotingType {

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/systemConfiguration/votingParamsManagement/voting/GetVotingTypes.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/systemConfiguration/votingParamsManagement/voting/GetVotingTypes.java
@@ -1,11 +1,11 @@
-package es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.voting;
+package es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.voting;
 
 import java.util.List;
 
-import es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.GetVotings;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.impl.PersistenceFactory;
-import es.uniovi.asw.dbmanagement.CandidacyRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.GetVotings;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.impl.PersistenceFactory;
+import es.uniovi.asw.dbManagement.CandidacyRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Eleccion;
 
 class GetVotingTypes {

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/systemConfiguration/votingParamsManagement/voting/VotingTypeService.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/systemConfiguration/votingParamsManagement/voting/VotingTypeService.java
@@ -1,9 +1,9 @@
-package es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.voting;
+package es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.voting;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.CandidacyRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.dbManagement.CandidacyRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Eleccion;
 
 public interface VotingTypeService {

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/systemConfiguration/votingParamsManagement/voting/VotingTypeServiceImpl.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/systemConfiguration/votingParamsManagement/voting/VotingTypeServiceImpl.java
@@ -1,9 +1,9 @@
-package es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.voting;
+package es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.voting;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.CandidacyRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.dbManagement.CandidacyRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Eleccion;
 
 public class VotingTypeServiceImpl implements VotingTypeService {

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/votingSystem/votingManagement/AlreadyVoted.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/votingSystem/votingManagement/AlreadyVoted.java
@@ -1,6 +1,6 @@
-package es.uniovi.asw.votingSystem.business.votingSystem.votingManagement;
+package es.uniovi.asw.VotingSystem.business.votingSystem.votingManagement;
 
-import es.uniovi.asw.dbmanagement.ConfirmedVoteRepository;
+import es.uniovi.asw.dbManagement.ConfirmedVoteRepository;
 import es.uniovi.asw.model.Voter;
 
 public interface AlreadyVoted {

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/votingSystem/votingManagement/GetActiveVotings.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/votingSystem/votingManagement/GetActiveVotings.java
@@ -1,8 +1,8 @@
-package es.uniovi.asw.votingSystem.business.votingSystem.votingManagement;
+package es.uniovi.asw.VotingSystem.business.votingSystem.votingManagement;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Eleccion;
 
 public interface GetActiveVotings {

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/votingSystem/votingManagement/GetVotingOptions.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/votingSystem/votingManagement/GetVotingOptions.java
@@ -1,8 +1,8 @@
-package es.uniovi.asw.votingSystem.business.votingSystem.votingManagement;
+package es.uniovi.asw.VotingSystem.business.votingSystem.votingManagement;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.CandidacyRepository;
+import es.uniovi.asw.dbManagement.CandidacyRepository;
 import es.uniovi.asw.model.Candidatura;
 
 public interface GetVotingOptions {

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/votingSystem/votingManagement/Vote.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/votingSystem/votingManagement/Vote.java
@@ -1,9 +1,9 @@
-package es.uniovi.asw.votingSystem.business.votingSystem.votingManagement;
+package es.uniovi.asw.VotingSystem.business.votingSystem.votingManagement;
 
-import es.uniovi.asw.dbmanagement.ConfirmedVoteRepository;
-import es.uniovi.asw.dbmanagement.VoteRepository;
-import es.uniovi.asw.dbmanagement.VoterRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.dbManagement.ConfirmedVoteRepository;
+import es.uniovi.asw.dbManagement.VoteRepository;
+import es.uniovi.asw.dbManagement.VoterRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Candidatura;
 import es.uniovi.asw.model.Voter;
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/votingSystem/votingManagement/impl/AlreadyVotedImpl.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/votingSystem/votingManagement/impl/AlreadyVotedImpl.java
@@ -1,8 +1,8 @@
-package es.uniovi.asw.votingSystem.business.votingSystem.votingManagement.impl;
+package es.uniovi.asw.VotingSystem.business.votingSystem.votingManagement.impl;
 
-import es.uniovi.asw.votingSystem.business.votingSystem.votingManagement.AlreadyVoted;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement.impl.PersistenceFactory;
-import es.uniovi.asw.dbmanagement.ConfirmedVoteRepository;
+import es.uniovi.asw.VotingSystem.business.votingSystem.votingManagement.AlreadyVoted;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement.impl.PersistenceFactory;
+import es.uniovi.asw.dbManagement.ConfirmedVoteRepository;
 import es.uniovi.asw.model.Voter;
 
 class AlreadyVotedImpl implements AlreadyVoted {

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/votingSystem/votingManagement/impl/GetActiveVotingsImpl.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/votingSystem/votingManagement/impl/GetActiveVotingsImpl.java
@@ -1,12 +1,12 @@
-package es.uniovi.asw.votingSystem.business.votingSystem.votingManagement.impl;
+package es.uniovi.asw.VotingSystem.business.votingSystem.votingManagement.impl;
 
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import es.uniovi.asw.votingSystem.business.votingSystem.votingManagement.GetActiveVotings;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement.impl.PersistenceFactory;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.VotingSystem.business.votingSystem.votingManagement.GetActiveVotings;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement.impl.PersistenceFactory;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Eleccion;
 
 class GetActiveVotingsImpl implements GetActiveVotings {

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/votingSystem/votingManagement/impl/GetVotingOptionsImpl.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/votingSystem/votingManagement/impl/GetVotingOptionsImpl.java
@@ -1,11 +1,11 @@
-package es.uniovi.asw.votingSystem.business.votingSystem.votingManagement.impl;
+package es.uniovi.asw.VotingSystem.business.votingSystem.votingManagement.impl;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import es.uniovi.asw.votingSystem.business.votingSystem.votingManagement.GetVotingOptions;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement.impl.PersistenceFactory;
-import es.uniovi.asw.dbmanagement.CandidacyRepository;
+import es.uniovi.asw.VotingSystem.business.votingSystem.votingManagement.GetVotingOptions;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement.impl.PersistenceFactory;
+import es.uniovi.asw.dbManagement.CandidacyRepository;
 import es.uniovi.asw.model.Candidatura;
 
 class GetVotingOptionsImpl implements GetVotingOptions {

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/votingSystem/votingManagement/impl/ServicesFactory.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/votingSystem/votingManagement/impl/ServicesFactory.java
@@ -1,9 +1,9 @@
-package es.uniovi.asw.votingSystem.business.votingSystem.votingManagement.impl;
+package es.uniovi.asw.VotingSystem.business.votingSystem.votingManagement.impl;
 
-import es.uniovi.asw.votingSystem.business.votingSystem.votingManagement.AlreadyVoted;
-import es.uniovi.asw.votingSystem.business.votingSystem.votingManagement.GetActiveVotings;
-import es.uniovi.asw.votingSystem.business.votingSystem.votingManagement.GetVotingOptions;
-import es.uniovi.asw.votingSystem.business.votingSystem.votingManagement.Vote;
+import es.uniovi.asw.VotingSystem.business.votingSystem.votingManagement.AlreadyVoted;
+import es.uniovi.asw.VotingSystem.business.votingSystem.votingManagement.GetActiveVotings;
+import es.uniovi.asw.VotingSystem.business.votingSystem.votingManagement.GetVotingOptions;
+import es.uniovi.asw.VotingSystem.business.votingSystem.votingManagement.Vote;
 
 public class ServicesFactory {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/votingSystem/votingManagement/impl/VoteImpl.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/business/votingSystem/votingManagement/impl/VoteImpl.java
@@ -1,11 +1,11 @@
-package es.uniovi.asw.votingSystem.business.votingSystem.votingManagement.impl;
+package es.uniovi.asw.VotingSystem.business.votingSystem.votingManagement.impl;
 
-import es.uniovi.asw.votingSystem.business.votingSystem.votingManagement.Vote;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement.impl.PersistenceFactory;
-import es.uniovi.asw.dbmanagement.ConfirmedVoteRepository;
-import es.uniovi.asw.dbmanagement.VoteRepository;
-import es.uniovi.asw.dbmanagement.VoterRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.VotingSystem.business.votingSystem.votingManagement.Vote;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement.impl.PersistenceFactory;
+import es.uniovi.asw.dbManagement.ConfirmedVoteRepository;
+import es.uniovi.asw.dbManagement.VoteRepository;
+import es.uniovi.asw.dbManagement.VoterRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Candidatura;
 import es.uniovi.asw.model.Eleccion;
 import es.uniovi.asw.model.Voter;

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/controller/DatabaseConfig.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/controller/DatabaseConfig.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.votingSystem.controller;
+package es.uniovi.asw.VotingSystem.controller;
 /*
 import javax.sql.DataSource;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceBuilder;

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/controller/Main.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/controller/Main.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.votingSystem.controller;
+package es.uniovi.asw.VotingSystem.controller;
 
 import java.util.List;
 
@@ -17,36 +17,31 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
 
-//import es.uniovi.asw.votingSystem.view.registerVote.pollingStationPresidentManagement.GetAV;
-//import es.uniovi.asw.votingSystem.view.registerVote.pollingStationPresidentManagement.GetAV;
-
-
-import es.uniovi.asw.dbmanagement.CandidacyRepository;
-import es.uniovi.asw.dbmanagement.CircumscriptionRepository;
-import es.uniovi.asw.dbmanagement.ConfirmedVoteRepository;
-import es.uniovi.asw.dbmanagement.PollingStationRepository;
-import es.uniovi.asw.dbmanagement.VoteRepository;
-import es.uniovi.asw.dbmanagement.VoterRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.VotingSystem.business.login.Authenticate;
+import es.uniovi.asw.VotingSystem.view.registerVote.pollingStationPresidentManagement.AddPV;
+import es.uniovi.asw.VotingSystem.view.registerVote.pollingStationPresidentManagement.CheckV;
+import es.uniovi.asw.VotingSystem.view.registerVote.pollingStationPresidentManagement.GetV;
+import es.uniovi.asw.VotingSystem.view.systemConfiguration.administratorManagement.ConfCand;
+import es.uniovi.asw.VotingSystem.view.systemConfiguration.administratorManagement.ConfPS;
+import es.uniovi.asw.VotingSystem.view.systemConfiguration.administratorManagement.ConfVT;
+import es.uniovi.asw.VotingSystem.view.systemConfiguration.administratorManagement.GetCand;
+import es.uniovi.asw.VotingSystem.view.systemConfiguration.administratorManagement.GetPS;
+import es.uniovi.asw.VotingSystem.view.systemConfiguration.administratorManagement.GetVT;
+import es.uniovi.asw.VotingSystem.view.votingSystem.voterManagement.AlreadyV;
+import es.uniovi.asw.VotingSystem.view.votingSystem.voterManagement.GetAV;
+import es.uniovi.asw.VotingSystem.view.votingSystem.voterManagement.GetVO;
+import es.uniovi.asw.VotingSystem.view.votingSystem.voterManagement.VoteV;
+import es.uniovi.asw.dbManagement.CandidacyRepository;
+import es.uniovi.asw.dbManagement.CircumscriptionRepository;
+import es.uniovi.asw.dbManagement.ConfirmedVoteRepository;
+import es.uniovi.asw.dbManagement.PollingStationRepository;
+import es.uniovi.asw.dbManagement.VoteRepository;
+import es.uniovi.asw.dbManagement.VoterRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Candidatura;
 import es.uniovi.asw.model.ColegioElectoral;
 import es.uniovi.asw.model.Eleccion;
 import es.uniovi.asw.model.Voter;
-import es.uniovi.asw.votingSystem.business.login.Authenticate;
-import es.uniovi.asw.votingSystem.view.registerVote.pollingStationPresidentManagement.AddPV;
-import es.uniovi.asw.votingSystem.view.registerVote.pollingStationPresidentManagement.CheckV;
-import es.uniovi.asw.votingSystem.view.registerVote.pollingStationPresidentManagement.GetV;
-import es.uniovi.asw.votingSystem.view.systemConfiguration.administratorManagement.ConfCand;
-import es.uniovi.asw.votingSystem.view.systemConfiguration.administratorManagement.ConfPS;
-import es.uniovi.asw.votingSystem.view.systemConfiguration.administratorManagement.ConfVT;
-import es.uniovi.asw.votingSystem.view.systemConfiguration.administratorManagement.GetCand;
-import es.uniovi.asw.votingSystem.view.systemConfiguration.administratorManagement.GetPS;
-import es.uniovi.asw.votingSystem.view.systemConfiguration.administratorManagement.GetVT;
-import es.uniovi.asw.votingSystem.view.votingSystem.voterManagement.AlreadyV;
-import es.uniovi.asw.votingSystem.view.votingSystem.voterManagement.GetAV;
-//import es.uniovi.asw.votingSystem.view.votingSystem.voterManagement.GetAV;
-import es.uniovi.asw.votingSystem.view.votingSystem.voterManagement.GetVO;
-import es.uniovi.asw.votingSystem.view.votingSystem.voterManagement.VoteV;
 
 @Controller
 public class Main {
@@ -243,8 +238,8 @@ public class Main {
 			model.addAttribute("mensaje", "El votante no ha votado");
 		}
 		model.addAttribute("elecciones",
-				// import .GetAV;
-				new es.uniovi.asw.votingSystem.view.registerVote.pollingStationPresidentManagement.GetAV(vRep).getAV(vRep));
+				new es.uniovi.asw.VotingSystem.view.registerVote.pollingStationPresidentManagement.GetAV(vRep)
+						.getAV(vRep));
 		model.addAttribute("votantes", new GetV(vtRep).getV(vtRep));
 
 		return new ModelAndView("president_index");

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/adminDBManagement/AddCandidacyC.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/adminDBManagement/AddCandidacyC.java
@@ -1,9 +1,9 @@
-package es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement;
+package es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.CandidacyRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.dbManagement.CandidacyRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Candidatura;
 
 public interface AddCandidacyC {

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/adminDBManagement/AddPollingStation.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/adminDBManagement/AddPollingStation.java
@@ -1,6 +1,6 @@
-package es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement;
+package es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement;
 
-import es.uniovi.asw.dbmanagement.PollingStationRepository;
+import es.uniovi.asw.dbManagement.PollingStationRepository;
 import es.uniovi.asw.model.ColegioElectoral;
 
 public interface AddPollingStation {

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/adminDBManagement/AddVotingType.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/adminDBManagement/AddVotingType.java
@@ -1,7 +1,7 @@
-package es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement;
+package es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement;
 
-import es.uniovi.asw.dbmanagement.CandidacyRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.dbManagement.CandidacyRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Eleccion;
 
 public interface AddVotingType {

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/adminDBManagement/GetCandidacyS.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/adminDBManagement/GetCandidacyS.java
@@ -1,9 +1,9 @@
-package es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement;
+package es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.CandidacyRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.dbManagement.CandidacyRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Candidatura;
 
 public interface GetCandidacyS {

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/adminDBManagement/GetPollingStationsP.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/adminDBManagement/GetPollingStationsP.java
@@ -1,9 +1,9 @@
-package es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement;
+package es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.CircumscriptionRepository;
-import es.uniovi.asw.dbmanagement.PollingStationRepository;
+import es.uniovi.asw.dbManagement.CircumscriptionRepository;
+import es.uniovi.asw.dbManagement.PollingStationRepository;
 import es.uniovi.asw.model.Circunscripcion;
 import es.uniovi.asw.model.ColegioElectoral;
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/adminDBManagement/GetVotings.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/adminDBManagement/GetVotings.java
@@ -1,9 +1,9 @@
-package es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement;
+package es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.CandidacyRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.dbManagement.CandidacyRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Eleccion;
 
 public interface GetVotings {

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/adminDBManagement/impl/AddCandidacyCImpl.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/adminDBManagement/impl/AddCandidacyCImpl.java
@@ -1,12 +1,12 @@
-package es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.impl;
+package es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.impl;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.CandidacyRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.AddCandidacyC;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.GetCandidacyS;
+import es.uniovi.asw.dbManagement.CandidacyRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Candidatura;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.AddCandidacyC;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.GetCandidacyS;
 
 class AddCandidacyCImpl implements AddCandidacyC {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/adminDBManagement/impl/AddPollingStationImpl.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/adminDBManagement/impl/AddPollingStationImpl.java
@@ -1,8 +1,8 @@
-package es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.impl;
+package es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.impl;
 
-import es.uniovi.asw.dbmanagement.PollingStationRepository;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.AddPollingStation;
+import es.uniovi.asw.dbManagement.PollingStationRepository;
 import es.uniovi.asw.model.ColegioElectoral;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.AddPollingStation;
 
 class AddPollingStationImpl implements AddPollingStation {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/adminDBManagement/impl/AddVotingTypeImpl.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/adminDBManagement/impl/AddVotingTypeImpl.java
@@ -1,12 +1,12 @@
-package es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.impl;
+package es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.impl;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.CandidacyRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.AddVotingType;
+import es.uniovi.asw.dbManagement.CandidacyRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Candidatura;
 import es.uniovi.asw.model.Eleccion;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.AddVotingType;
 
 class AddVotingTypeImpl implements AddVotingType {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/adminDBManagement/impl/GetCandidacySImpl.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/adminDBManagement/impl/GetCandidacySImpl.java
@@ -1,12 +1,12 @@
-package es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.impl;
+package es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.impl;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.CandidacyRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.GetCandidacyS;
+import es.uniovi.asw.dbManagement.CandidacyRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Candidatura;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.GetCandidacyS;
 
 class GetCandidacySImpl implements GetCandidacyS {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/adminDBManagement/impl/GetPollingStationsPImpl.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/adminDBManagement/impl/GetPollingStationsPImpl.java
@@ -1,12 +1,12 @@
-package es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.impl;
+package es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.impl;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.CircumscriptionRepository;
-import es.uniovi.asw.dbmanagement.PollingStationRepository;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.GetPollingStationsP;
+import es.uniovi.asw.dbManagement.CircumscriptionRepository;
+import es.uniovi.asw.dbManagement.PollingStationRepository;
 import es.uniovi.asw.model.Circunscripcion;
 import es.uniovi.asw.model.ColegioElectoral;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.GetPollingStationsP;
 
 class GetPollingStationsPImpl implements GetPollingStationsP {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/adminDBManagement/impl/GetVotingsImpl.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/adminDBManagement/impl/GetVotingsImpl.java
@@ -1,13 +1,13 @@
-package es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.impl;
+package es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.impl;
 
 import java.sql.Date;
 import java.util.ArrayList;
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.CandidacyRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.GetVotings;
+import es.uniovi.asw.dbManagement.CandidacyRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Eleccion;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.GetVotings;
 
 class GetVotingsImpl implements GetVotings {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/adminDBManagement/impl/PersistenceFactory.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/adminDBManagement/impl/PersistenceFactory.java
@@ -1,11 +1,11 @@
-package es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.impl;
+package es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.impl;
 
-import es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.AddCandidacyC;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.AddPollingStation;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.AddVotingType;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.GetCandidacyS;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.GetPollingStationsP;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.adminDBManagement.GetVotings;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.AddCandidacyC;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.AddPollingStation;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.AddVotingType;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.GetCandidacyS;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.GetPollingStationsP;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.adminDBManagement.GetVotings;
 
 public class PersistenceFactory {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/votingDBManagement/AddVote.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/votingDBManagement/AddVote.java
@@ -1,7 +1,7 @@
-package es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement;
+package es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement;
 
-import es.uniovi.asw.dbmanagement.ConfirmedVoteRepository;
-import es.uniovi.asw.dbmanagement.VoteRepository;
+import es.uniovi.asw.dbManagement.ConfirmedVoteRepository;
+import es.uniovi.asw.dbManagement.VoteRepository;
 import es.uniovi.asw.model.Voto;
 import es.uniovi.asw.model.VotoConfirmado;
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/votingDBManagement/GetActiveVotings.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/votingDBManagement/GetActiveVotings.java
@@ -1,8 +1,8 @@
-package es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement;
+package es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Eleccion;
 
 public interface GetActiveVotings {

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/votingDBManagement/GetVOptions.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/votingDBManagement/GetVOptions.java
@@ -1,8 +1,8 @@
-package es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement;
+package es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.CandidacyRepository;
+import es.uniovi.asw.dbManagement.CandidacyRepository;
 import es.uniovi.asw.model.Candidatura;
 import es.uniovi.asw.model.Eleccion;
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/votingDBManagement/GetVoters.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/votingDBManagement/GetVoters.java
@@ -1,8 +1,8 @@
-package es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement;
+package es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.VoterRepository;
+import es.uniovi.asw.dbManagement.VoterRepository;
 import es.uniovi.asw.model.Voter;
 
 public interface GetVoters {

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/votingDBManagement/HasVoted.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/votingDBManagement/HasVoted.java
@@ -1,6 +1,6 @@
-package es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement;
+package es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement;
 
-import es.uniovi.asw.dbmanagement.ConfirmedVoteRepository;
+import es.uniovi.asw.dbManagement.ConfirmedVoteRepository;
 
 public interface HasVoted {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/votingDBManagement/impl/AddVoteImpl.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/votingDBManagement/impl/AddVoteImpl.java
@@ -1,10 +1,10 @@
-package es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement.impl;
+package es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement.impl;
 
-import es.uniovi.asw.dbmanagement.ConfirmedVoteRepository;
-import es.uniovi.asw.dbmanagement.VoteRepository;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement.AddVote;
+import es.uniovi.asw.dbManagement.ConfirmedVoteRepository;
+import es.uniovi.asw.dbManagement.VoteRepository;
 import es.uniovi.asw.model.Voto;
 import es.uniovi.asw.model.VotoConfirmado;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement.AddVote;
 
 class AddVoteImpl implements AddVote {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/votingDBManagement/impl/GetActiveVotingsImpl.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/votingDBManagement/impl/GetActiveVotingsImpl.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement.impl;
+package es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement.impl;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -6,8 +6,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement.GetActiveVotings;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement.GetActiveVotings;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Eleccion;
 
 class GetActiveVotingsImpl implements GetActiveVotings {

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/votingDBManagement/impl/GetVOptionsImpl.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/votingDBManagement/impl/GetVOptionsImpl.java
@@ -1,11 +1,11 @@
-package es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement.impl;
+package es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement.impl;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.CandidacyRepository;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement.GetVOptions;
+import es.uniovi.asw.dbManagement.CandidacyRepository;
 import es.uniovi.asw.model.Candidatura;
 import es.uniovi.asw.model.Eleccion;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement.GetVOptions;
 
 class GetVOptionsImpl implements GetVOptions {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/votingDBManagement/impl/GetVotersImpl.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/votingDBManagement/impl/GetVotersImpl.java
@@ -1,9 +1,9 @@
-package es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement.impl;
+package es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement.impl;
 
 import java.util.List;
 
-import es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement.GetVoters;
-import es.uniovi.asw.dbmanagement.VoterRepository;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement.GetVoters;
+import es.uniovi.asw.dbManagement.VoterRepository;
 import es.uniovi.asw.model.Voter;
 
 class GetVotersImpl implements GetVoters {

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/votingDBManagement/impl/HasVotedImpl.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/votingDBManagement/impl/HasVotedImpl.java
@@ -1,10 +1,10 @@
-package es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement.impl;
+package es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement.impl;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.ConfirmedVoteRepository;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement.HasVoted;
+import es.uniovi.asw.dbManagement.ConfirmedVoteRepository;
 import es.uniovi.asw.model.VotoConfirmado;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement.HasVoted;
 
 class HasVotedImpl implements HasVoted {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/votingDBManagement/impl/PersistenceFactory.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/persistence/dbManagement/votingDBManagement/impl/PersistenceFactory.java
@@ -1,10 +1,10 @@
-package es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement.impl;
+package es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement.impl;
 
-import es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement.AddVote;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement.GetActiveVotings;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement.GetVOptions;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement.GetVoters;
-import es.uniovi.asw.votingSystem.persistence.dbManagement.votingDBManagement.HasVoted;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement.AddVote;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement.GetActiveVotings;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement.GetVOptions;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement.GetVoters;
+import es.uniovi.asw.VotingSystem.persistence.dbManagement.votingDBManagement.HasVoted;
 
 public class PersistenceFactory {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/view/registerVote/pollingStationPresidentManagement/AddPV.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/view/registerVote/pollingStationPresidentManagement/AddPV.java
@@ -1,10 +1,10 @@
-package es.uniovi.asw.votingSystem.view.registerVote.pollingStationPresidentManagement;
+package es.uniovi.asw.VotingSystem.view.registerVote.pollingStationPresidentManagement;
 
-import es.uniovi.asw.dbmanagement.ConfirmedVoteRepository;
-import es.uniovi.asw.dbmanagement.VoterRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
-import es.uniovi.asw.votingSystem.business.registerVote.storePhisicalVoteManagement.PhysicalVoteService;
-import es.uniovi.asw.votingSystem.business.registerVote.storePhisicalVoteManagement.impl.PhysicalVoteServiceImpl;
+import es.uniovi.asw.VotingSystem.business.registerVote.storePhisicalVoteManagement.PhysicalVoteService;
+import es.uniovi.asw.VotingSystem.business.registerVote.storePhisicalVoteManagement.impl.PhysicalVoteServiceImpl;
+import es.uniovi.asw.dbManagement.ConfirmedVoteRepository;
+import es.uniovi.asw.dbManagement.VoterRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 
 public class AddPV {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/view/registerVote/pollingStationPresidentManagement/CheckV.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/view/registerVote/pollingStationPresidentManagement/CheckV.java
@@ -1,8 +1,8 @@
-package es.uniovi.asw.votingSystem.view.registerVote.pollingStationPresidentManagement;
+package es.uniovi.asw.VotingSystem.view.registerVote.pollingStationPresidentManagement;
 
-import es.uniovi.asw.dbmanagement.ConfirmedVoteRepository;
-import es.uniovi.asw.votingSystem.business.registerVote.storePhisicalVoteManagement.PhysicalVoteService;
-import es.uniovi.asw.votingSystem.business.registerVote.storePhisicalVoteManagement.impl.PhysicalVoteServiceImpl;
+import es.uniovi.asw.VotingSystem.business.registerVote.storePhisicalVoteManagement.PhysicalVoteService;
+import es.uniovi.asw.VotingSystem.business.registerVote.storePhisicalVoteManagement.impl.PhysicalVoteServiceImpl;
+import es.uniovi.asw.dbManagement.ConfirmedVoteRepository;
 
 public class CheckV {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/view/registerVote/pollingStationPresidentManagement/GetAV.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/view/registerVote/pollingStationPresidentManagement/GetAV.java
@@ -1,9 +1,9 @@
-package es.uniovi.asw.votingSystem.view.registerVote.pollingStationPresidentManagement;
+package es.uniovi.asw.VotingSystem.view.registerVote.pollingStationPresidentManagement;
 
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.VotingSystem.business.registerVote.storePhisicalVoteManagement.PhysicalVoteService;
+import es.uniovi.asw.VotingSystem.business.registerVote.storePhisicalVoteManagement.impl.PhysicalVoteServiceImpl;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Eleccion;
-import es.uniovi.asw.votingSystem.business.registerVote.storePhisicalVoteManagement.PhysicalVoteService;
-import es.uniovi.asw.votingSystem.business.registerVote.storePhisicalVoteManagement.impl.PhysicalVoteServiceImpl;
 
 public class GetAV {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/view/registerVote/pollingStationPresidentManagement/GetV.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/view/registerVote/pollingStationPresidentManagement/GetV.java
@@ -1,11 +1,11 @@
-package es.uniovi.asw.votingSystem.view.registerVote.pollingStationPresidentManagement;
+package es.uniovi.asw.VotingSystem.view.registerVote.pollingStationPresidentManagement;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.VoterRepository;
+import es.uniovi.asw.VotingSystem.business.registerVote.storePhisicalVoteManagement.PhysicalVoteService;
+import es.uniovi.asw.VotingSystem.business.registerVote.storePhisicalVoteManagement.impl.PhysicalVoteServiceImpl;
+import es.uniovi.asw.dbManagement.VoterRepository;
 import es.uniovi.asw.model.Voter;
-import es.uniovi.asw.votingSystem.business.registerVote.storePhisicalVoteManagement.PhysicalVoteService;
-import es.uniovi.asw.votingSystem.business.registerVote.storePhisicalVoteManagement.impl.PhysicalVoteServiceImpl;
 
 public class GetV {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/view/systemConfiguration/administratorManagement/ConfCand.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/view/systemConfiguration/administratorManagement/ConfCand.java
@@ -1,12 +1,12 @@
-package es.uniovi.asw.votingSystem.view.systemConfiguration.administratorManagement;
+package es.uniovi.asw.VotingSystem.view.systemConfiguration.administratorManagement;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.CandidacyRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.SysConfigServiceFactory;
+import es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.candidacyManagement.CandidacyService;
+import es.uniovi.asw.dbManagement.CandidacyRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Candidatura;
-import es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.SysConfigServiceFactory;
-import es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.candidacyManagement.CandidacyService;
 
 public class ConfCand {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/view/systemConfiguration/administratorManagement/ConfPS.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/view/systemConfiguration/administratorManagement/ConfPS.java
@@ -1,9 +1,9 @@
-package es.uniovi.asw.votingSystem.view.systemConfiguration.administratorManagement;
+package es.uniovi.asw.VotingSystem.view.systemConfiguration.administratorManagement;
 
-import es.uniovi.asw.dbmanagement.PollingStationRepository;
+import es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.SysConfigServiceFactory;
+import es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.pollingStationManagement.PollingStationService;
+import es.uniovi.asw.dbManagement.PollingStationRepository;
 import es.uniovi.asw.model.ColegioElectoral;
-import es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.SysConfigServiceFactory;
-import es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.pollingStationManagement.PollingStationService;
 
 public class ConfPS {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/view/systemConfiguration/administratorManagement/ConfVT.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/view/systemConfiguration/administratorManagement/ConfVT.java
@@ -1,10 +1,10 @@
-package es.uniovi.asw.votingSystem.view.systemConfiguration.administratorManagement;
+package es.uniovi.asw.VotingSystem.view.systemConfiguration.administratorManagement;
 
-import es.uniovi.asw.dbmanagement.CandidacyRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.SysConfigServiceFactory;
+import es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.voting.VotingTypeService;
+import es.uniovi.asw.dbManagement.CandidacyRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Eleccion;
-import es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.SysConfigServiceFactory;
-import es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.voting.VotingTypeService;
 
 public class ConfVT {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/view/systemConfiguration/administratorManagement/GetCand.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/view/systemConfiguration/administratorManagement/GetCand.java
@@ -1,12 +1,12 @@
-package es.uniovi.asw.votingSystem.view.systemConfiguration.administratorManagement;
+package es.uniovi.asw.VotingSystem.view.systemConfiguration.administratorManagement;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.CandidacyRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.SysConfigServiceFactory;
+import es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.candidacyManagement.CandidacyService;
+import es.uniovi.asw.dbManagement.CandidacyRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Candidatura;
-import es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.SysConfigServiceFactory;
-import es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.candidacyManagement.CandidacyService;
 
 public class GetCand {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/view/systemConfiguration/administratorManagement/GetPS.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/view/systemConfiguration/administratorManagement/GetPS.java
@@ -1,13 +1,13 @@
-package es.uniovi.asw.votingSystem.view.systemConfiguration.administratorManagement;
+package es.uniovi.asw.VotingSystem.view.systemConfiguration.administratorManagement;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.CircumscriptionRepository;
-import es.uniovi.asw.dbmanagement.PollingStationRepository;
+import es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.SysConfigServiceFactory;
+import es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.pollingStationManagement.PollingStationService;
+import es.uniovi.asw.dbManagement.CircumscriptionRepository;
+import es.uniovi.asw.dbManagement.PollingStationRepository;
 import es.uniovi.asw.model.Circunscripcion;
 import es.uniovi.asw.model.ColegioElectoral;
-import es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.SysConfigServiceFactory;
-import es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.pollingStationManagement.PollingStationService;
 
 public class GetPS {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/view/systemConfiguration/administratorManagement/GetVT.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/view/systemConfiguration/administratorManagement/GetVT.java
@@ -1,12 +1,12 @@
-package es.uniovi.asw.votingSystem.view.systemConfiguration.administratorManagement;
+package es.uniovi.asw.VotingSystem.view.systemConfiguration.administratorManagement;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.CandidacyRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.SysConfigServiceFactory;
+import es.uniovi.asw.VotingSystem.business.systemConfiguration.votingParamsManagement.voting.VotingTypeService;
+import es.uniovi.asw.dbManagement.CandidacyRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Eleccion;
-import es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.SysConfigServiceFactory;
-import es.uniovi.asw.votingSystem.business.systemConfiguration.votingParamsManagement.voting.VotingTypeService;
 
 public class GetVT {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/view/votingSystem/voterManagement/AlreadyV.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/view/votingSystem/voterManagement/AlreadyV.java
@@ -1,8 +1,8 @@
-package es.uniovi.asw.votingSystem.view.votingSystem.voterManagement;
+package es.uniovi.asw.VotingSystem.view.votingSystem.voterManagement;
 
-import es.uniovi.asw.dbmanagement.ConfirmedVoteRepository;
+import es.uniovi.asw.VotingSystem.business.votingSystem.votingManagement.impl.ServicesFactory;
+import es.uniovi.asw.dbManagement.ConfirmedVoteRepository;
 import es.uniovi.asw.model.Voter;
-import es.uniovi.asw.votingSystem.business.votingSystem.votingManagement.impl.ServicesFactory;
 
 public class AlreadyV {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/view/votingSystem/voterManagement/GetAV.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/view/votingSystem/voterManagement/GetAV.java
@@ -1,10 +1,10 @@
-package es.uniovi.asw.votingSystem.view.votingSystem.voterManagement;
+package es.uniovi.asw.VotingSystem.view.votingSystem.voterManagement;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.VotingSystem.business.votingSystem.votingManagement.impl.ServicesFactory;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Eleccion;
-import es.uniovi.asw.votingSystem.business.votingSystem.votingManagement.impl.ServicesFactory;
 
 public class GetAV {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/view/votingSystem/voterManagement/GetVO.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/view/votingSystem/voterManagement/GetVO.java
@@ -1,10 +1,10 @@
-package es.uniovi.asw.votingSystem.view.votingSystem.voterManagement;
+package es.uniovi.asw.VotingSystem.view.votingSystem.voterManagement;
 
 import java.util.List;
 
-import es.uniovi.asw.dbmanagement.CandidacyRepository;
+import es.uniovi.asw.VotingSystem.business.votingSystem.votingManagement.impl.ServicesFactory;
+import es.uniovi.asw.dbManagement.CandidacyRepository;
 import es.uniovi.asw.model.Candidatura;
-import es.uniovi.asw.votingSystem.business.votingSystem.votingManagement.impl.ServicesFactory;
 
 public class GetVO {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/view/votingSystem/voterManagement/VoteV.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/VotingSystem/view/votingSystem/voterManagement/VoteV.java
@@ -1,12 +1,12 @@
-package es.uniovi.asw.votingSystem.view.votingSystem.voterManagement;
+package es.uniovi.asw.VotingSystem.view.votingSystem.voterManagement;
 
-import es.uniovi.asw.dbmanagement.ConfirmedVoteRepository;
-import es.uniovi.asw.dbmanagement.VoteRepository;
-import es.uniovi.asw.dbmanagement.VoterRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.VotingSystem.business.votingSystem.votingManagement.impl.ServicesFactory;
+import es.uniovi.asw.dbManagement.ConfirmedVoteRepository;
+import es.uniovi.asw.dbManagement.VoteRepository;
+import es.uniovi.asw.dbManagement.VoterRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Candidatura;
 import es.uniovi.asw.model.Voter;
-import es.uniovi.asw.votingSystem.business.votingSystem.votingManagement.impl.ServicesFactory;
 
 public class VoteV {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/dbManagement/CandidacyRepository.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/dbManagement/CandidacyRepository.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.dbmanagement;
+package es.uniovi.asw.dbManagement;
 
 import java.util.List;
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/dbManagement/CircumscriptionRepository.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/dbManagement/CircumscriptionRepository.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.dbmanagement;
+package es.uniovi.asw.dbManagement;
 
 import org.springframework.data.repository.CrudRepository;
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/dbManagement/ComunidadRepository.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/dbManagement/ComunidadRepository.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.dbmanagement;
+package es.uniovi.asw.dbManagement;
 
 import org.springframework.data.repository.CrudRepository;
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/dbManagement/ConfirmedVoteRepository.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/dbManagement/ConfirmedVoteRepository.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.dbmanagement;
+package es.uniovi.asw.dbManagement;
 
 import org.springframework.data.repository.CrudRepository;
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/dbManagement/Persistence.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/dbManagement/Persistence.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.dbmanagement;
+package es.uniovi.asw.dbManagement;
 
 public class Persistence {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/dbManagement/PollingStationRepository.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/dbManagement/PollingStationRepository.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.dbmanagement;
+package es.uniovi.asw.dbManagement;
 
 import org.springframework.data.repository.CrudRepository;
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/dbManagement/VoteRepository.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/dbManagement/VoteRepository.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.dbmanagement;
+package es.uniovi.asw.dbManagement;
 
 import org.springframework.data.repository.CrudRepository;
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/dbManagement/VoterRepository.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/dbManagement/VoterRepository.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.dbmanagement;
+package es.uniovi.asw.dbManagement;
 
 import java.util.List;
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/dbManagement/VotingRepository.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/dbManagement/VotingRepository.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.dbmanagement;
+package es.uniovi.asw.dbManagement;
 
 import java.util.List;
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/dbManagement/impl/DBManagementImpl.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/dbManagement/impl/DBManagementImpl.java
@@ -1,10 +1,10 @@
-package es.uniovi.asw.dbmanagement.impl;
+package es.uniovi.asw.dbManagement.impl;
 
-import es.uniovi.asw.dbmanagement.Persistence;
-import es.uniovi.asw.dbmanagement.VoterRepository;
+import es.uniovi.asw.Voters.types.ChangePass;
+import es.uniovi.asw.Voters.types.UserPass;
+import es.uniovi.asw.dbManagement.Persistence;
+import es.uniovi.asw.dbManagement.VoterRepository;
 import es.uniovi.asw.model.Voter;
-import es.uniovi.asw.voters.types.ChangePass;
-import es.uniovi.asw.voters.types.UserPass;
 
 public class DBManagementImpl {
 

--- a/VotingSystem/src/main/java/es/uniovi/asw/dbManagement/impl/RepositoryConfiguration.java
+++ b/VotingSystem/src/main/java/es/uniovi/asw/dbManagement/impl/RepositoryConfiguration.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.dbmanagement.impl;
+package es.uniovi.asw.dbManagement.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -7,15 +7,15 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
-import es.uniovi.asw.dbmanagement.CandidacyRepository;
-import es.uniovi.asw.dbmanagement.CircumscriptionRepository;
-import es.uniovi.asw.dbmanagement.ComunidadRepository;
-import es.uniovi.asw.dbmanagement.ConfirmedVoteRepository;
-import es.uniovi.asw.dbmanagement.Persistence;
-import es.uniovi.asw.dbmanagement.PollingStationRepository;
-import es.uniovi.asw.dbmanagement.VoteRepository;
-import es.uniovi.asw.dbmanagement.VoterRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.dbManagement.CandidacyRepository;
+import es.uniovi.asw.dbManagement.CircumscriptionRepository;
+import es.uniovi.asw.dbManagement.ComunidadRepository;
+import es.uniovi.asw.dbManagement.ConfirmedVoteRepository;
+import es.uniovi.asw.dbManagement.Persistence;
+import es.uniovi.asw.dbManagement.PollingStationRepository;
+import es.uniovi.asw.dbManagement.VoteRepository;
+import es.uniovi.asw.dbManagement.VoterRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Candidatura;
 import es.uniovi.asw.model.Circunscripcion;
 import es.uniovi.asw.model.ColegioElectoral;
@@ -27,7 +27,7 @@ import es.uniovi.asw.model.Voto;
 @Configuration
 @EnableAutoConfiguration
 @EntityScan(basePackages = { "es.uniovi.asw.model" })
-@EnableJpaRepositories(basePackages = { "es.uniovi.asw.dbmanagement" })
+@EnableJpaRepositories(basePackages = { "es.uniovi.asw.dbManagement" })
 @EnableTransactionManagement
 public class RepositoryConfiguration {
 

--- a/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/CucumberTest.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/CucumberTest.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.votecounting;
+package es.uniovi.asw.VoteCounting;
 
 // import org.junit.runner.RunWith;
 

--- a/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/SeleniumUtils.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/SeleniumUtils.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.votecounting;
+package es.uniovi.asw.VoteCounting;
 
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/cobertura/Types/UserPassInitStopTest.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/cobertura/Types/UserPassInitStopTest.java
@@ -1,7 +1,7 @@
 /**
  * 
  */
-package es.uniovi.asw.votecounting.cobertura.types;
+package es.uniovi.asw.VoteCounting.cobertura.Types;
 
 import static org.junit.Assert.assertEquals;
 

--- a/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/cobertura/Types/VotoConfirmadokeyTest.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/cobertura/Types/VotoConfirmadokeyTest.java
@@ -1,7 +1,7 @@
 /**
  * 
  */
-package es.uniovi.asw.votecounting.cobertura.types;
+package es.uniovi.asw.VoteCounting.cobertura.Types;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/cobertura/modelo/CandidaturaTest.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/cobertura/modelo/CandidaturaTest.java
@@ -1,7 +1,7 @@
 /**
  * Un test del models y no trabajo para tripAdvisor ojo... este es otro models. 
  */
-package es.uniovi.asw.votecounting.cobertura.modelo;
+package es.uniovi.asw.VoteCounting.cobertura.modelo;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/cobertura/modelo/CircunscripcionTest.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/cobertura/modelo/CircunscripcionTest.java
@@ -1,6 +1,7 @@
-
-
-package es.uniovi.asw.votecounting.cobertura.modelo;
+/**
+ * Un test del models y no trabajo para tripAdvisor ojo... este es otro models. 
+ */
+package es.uniovi.asw.VoteCounting.cobertura.modelo;
 
 import static org.junit.Assert.*;
 

--- a/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/cobertura/modelo/ColegioElectoralTest.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/cobertura/modelo/ColegioElectoralTest.java
@@ -1,7 +1,7 @@
 /**
  * 
  */
-package es.uniovi.asw.votecounting.cobertura.modelo;
+package es.uniovi.asw.VoteCounting.cobertura.modelo;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/cobertura/modelo/ComunidadAutonomaTest.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/cobertura/modelo/ComunidadAutonomaTest.java
@@ -1,7 +1,7 @@
 /**
  * 
  */
-package es.uniovi.asw.votecounting.cobertura.modelo;
+package es.uniovi.asw.VoteCounting.cobertura.modelo;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/cobertura/modelo/EleccionTest.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/cobertura/modelo/EleccionTest.java
@@ -1,7 +1,7 @@
 /**
  * 
  */
-package es.uniovi.asw.votecounting.cobertura.modelo;
+package es.uniovi.asw.VoteCounting.cobertura.modelo;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/cobertura/modelo/VoterTest.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/cobertura/modelo/VoterTest.java
@@ -1,7 +1,7 @@
 /**
  * 
  */
-package es.uniovi.asw.votecounting.cobertura.modelo;
+package es.uniovi.asw.VoteCounting.cobertura.modelo;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/cobertura/modelo/VotoConfirmadoTest.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/cobertura/modelo/VotoConfirmadoTest.java
@@ -1,7 +1,7 @@
 /**
  * 
  */
-package es.uniovi.asw.votecounting.cobertura.modelo;
+package es.uniovi.asw.VoteCounting.cobertura.modelo;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/cobertura/modelo/VotoTest.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/cobertura/modelo/VotoTest.java
@@ -1,7 +1,7 @@
 /**
  * 
  */
-package es.uniovi.asw.votecounting.cobertura.modelo;
+package es.uniovi.asw.VoteCounting.cobertura.modelo;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/steps/DespliegeSteps.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/steps/DespliegeSteps.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.votecounting.steps;
+package es.uniovi.asw.VoteCounting.steps;
 
 import org.openqa.selenium.WebDriver;
 import org.springframework.boot.test.IntegrationTest;
@@ -6,7 +6,7 @@ import org.springframework.test.context.web.WebAppConfiguration;
 
 import cucumber.api.java.es.Cuando;
 import cucumber.api.java.es.Entonces;
-import es.uniovi.asw.votecounting.SeleniumUtils;
+import es.uniovi.asw.VoteCounting.SeleniumUtils;
 
 @IntegrationTest
 @WebAppConfiguration

--- a/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/steps/EleccionesSteps.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/steps/EleccionesSteps.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.votecounting.steps;
+package es.uniovi.asw.VoteCounting.steps;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
@@ -8,7 +8,7 @@ import org.springframework.boot.test.IntegrationTest;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import cucumber.api.java.es.Entonces;
-import es.uniovi.asw.votecounting.SeleniumUtils;
+import es.uniovi.asw.VoteCounting.SeleniumUtils;
 
 @IntegrationTest
 @WebAppConfiguration

--- a/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/steps/EstadisticasSteps.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/VoteCounting/steps/EstadisticasSteps.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.votecounting.steps;
+package es.uniovi.asw.VoteCounting.steps;
 
 import java.util.List;
 
@@ -10,7 +10,7 @@ import org.springframework.boot.test.IntegrationTest;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import cucumber.api.java.es.Entonces;
-import es.uniovi.asw.votecounting.SeleniumUtils;
+import es.uniovi.asw.VoteCounting.SeleniumUtils;
 
 @IntegrationTest
 @WebAppConfiguration

--- a/VotingSystem/src/test/java/es/uniovi/asw/Voters/dbManagerTests/DBManagementImplTest.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/Voters/dbManagerTests/DBManagementImplTest.java
@@ -1,9 +1,6 @@
-package es.uniovi.asw.voters.dbmanagertests;
+package es.uniovi.asw.Voters.dbManagerTests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import org.junit.After;
 import org.junit.Test;
@@ -15,13 +12,13 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import es.uniovi.asw.Application;
-import es.uniovi.asw.dbmanagement.Persistence;
-import es.uniovi.asw.dbmanagement.VoterRepository;
-import es.uniovi.asw.dbmanagement.impl.DBManagementImpl;
+import es.uniovi.asw.Voters.types.ChangePass;
+import es.uniovi.asw.Voters.types.Encrypter;
+import es.uniovi.asw.Voters.types.UserPass;
+import es.uniovi.asw.dbManagement.Persistence;
+import es.uniovi.asw.dbManagement.VoterRepository;
+import es.uniovi.asw.dbManagement.impl.DBManagementImpl;
 import es.uniovi.asw.model.Voter;
-import es.uniovi.asw.voters.types.ChangePass;
-import es.uniovi.asw.voters.types.Encrypter;
-import es.uniovi.asw.voters.types.UserPass;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = Application.class)

--- a/VotingSystem/src/test/java/es/uniovi/asw/Voters/dbManagerTests/DBManagementVirtualTest.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/Voters/dbManagerTests/DBManagementVirtualTest.java
@@ -1,24 +1,12 @@
-package es.uniovi.asw.voters.dbmanagertests;
-/*
+package es.uniovi.asw.Voters.dbManagerTests;
+
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.IntegrationTest;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
-import es.uniovi.asw.Application;
-*/
-
-
-/*
- * ********************************    PROBLEMAS CON TRAVIS  ********************************     
- * *																						*
- * *																						*
- * * COMENTADO POR PROBLEMAS CON TRAVIS. DESCOMENTAR Y EJECUTAR EN LOCAL. 					*
- * *																						*
- * *																						*
- * ********************************    PROBLEMAS CON TRAVIS  ********************************  
- */
+import es.uniovi.asw.Application;;
 
 //@RunWith(SpringJUnit4ClassRunner.class)
 //@SpringApplicationConfiguration(classes = Application.class)

--- a/VotingSystem/src/test/java/es/uniovi/asw/Voters/exceptionsTest/ExceptionTests.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/Voters/exceptionsTest/ExceptionTests.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.voters.exceptionstest;
+package es.uniovi.asw.Voters.exceptionsTest;
 
 import static org.junit.Assert.assertTrue;
 
@@ -10,8 +10,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import es.uniovi.asw.Application;
-import es.uniovi.asw.voters.exceptions.UserNotFoundException;
-import es.uniovi.asw.voters.types.UserPass;
+import es.uniovi.asw.Voters.exceptions.UserNotFoundException;
+import es.uniovi.asw.Voters.types.UserPass;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = Application.class)

--- a/VotingSystem/src/test/java/es/uniovi/asw/Voters/modelsTests/VoterTest.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/Voters/modelsTests/VoterTest.java
@@ -1,7 +1,7 @@
 /**
  * 
  */
-package es.uniovi.asw.voters.modelstests;
+package es.uniovi.asw.Voters.modelsTests;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/VotingSystem/src/test/java/es/uniovi/asw/Voters/testSuite/AllTests.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/Voters/testSuite/AllTests.java
@@ -1,22 +1,22 @@
-package es.uniovi.asw.voters.testsuite;
+package es.uniovi.asw.Voters.testSuite;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import es.uniovi.asw.voters.dbmanagertests.DBManagementImplTest;
-//import es.uniovi.asw.voters.dbmanagertests.DBManagementVirtualTest;
-import es.uniovi.asw.voters.exceptionstest.ExceptionTests;
-import es.uniovi.asw.voters.modelstests.VoterTest;
-import es.uniovi.asw.voters.typestests.ChangePassTest;
-import es.uniovi.asw.voters.typestests.EncrypterTest;
-import es.uniovi.asw.voters.typestests.UserInfoTest;
-import es.uniovi.asw.voters.typestests.UserPassTest;
-import es.uniovi.asw.voters.voteraccess.MainControllerTest;
+import es.uniovi.asw.Voters.dbManagerTests.DBManagementImplTest;
+//import es.uniovi.asw.Voters.dbManagerTests.DBManagementVirtualTest;
+import es.uniovi.asw.Voters.exceptionsTest.ExceptionTests;
+import es.uniovi.asw.Voters.modelsTests.VoterTest;
+import es.uniovi.asw.Voters.typesTests.ChangePassTest;
+import es.uniovi.asw.Voters.typesTests.EncrypterTest;
+import es.uniovi.asw.Voters.typesTests.UserInfoTest;
+import es.uniovi.asw.Voters.typesTests.UserPassTest;
+import es.uniovi.asw.Voters.voterAccess.MainControllerTest;
 
 @RunWith(Suite.class)
 @SuiteClasses({ ChangePassTest.class, EncrypterTest.class, UserInfoTest.class, UserPassTest.class,
-		 //DBManagementVirtualTest.class,
+		// DBManagementVirtualTest.class,
 		ExceptionTests.class, VoterTest.class, MainControllerTest.class, DBManagementImplTest.class, })
 public class AllTests {
 }

--- a/VotingSystem/src/test/java/es/uniovi/asw/Voters/typesTests/ChangePassTest.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/Voters/typesTests/ChangePassTest.java
@@ -1,7 +1,7 @@
 /**
  * 
  */
-package es.uniovi.asw.voters.typestests;
+package es.uniovi.asw.Voters.typesTests;
 
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -14,7 +14,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import es.uniovi.asw.Application;
-import es.uniovi.asw.voters.types.ChangePass;
+import es.uniovi.asw.Voters.types.ChangePass;
 
 /**
  * @author Amir H Tofigh Halati

--- a/VotingSystem/src/test/java/es/uniovi/asw/Voters/typesTests/EncrypterTest.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/Voters/typesTests/EncrypterTest.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.voters.typestests;
+package es.uniovi.asw.Voters.typesTests;
 
 import static org.junit.Assert.assertTrue;
 
@@ -10,7 +10,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import es.uniovi.asw.Application;
-import es.uniovi.asw.voters.types.Encrypter;
+
+import es.uniovi.asw.Voters.types.*;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = Application.class)

--- a/VotingSystem/src/test/java/es/uniovi/asw/Voters/typesTests/UserInfoTest.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/Voters/typesTests/UserInfoTest.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.voters.typestests;
+package es.uniovi.asw.Voters.typesTests;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -12,8 +12,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import es.uniovi.asw.Application;
-import es.uniovi.asw.voters.types.ChangePass;
-import es.uniovi.asw.voters.types.UserInfo;
+import es.uniovi.asw.Voters.types.ChangePass;
+import es.uniovi.asw.Voters.types.UserInfo;
 import es.uniovi.asw.model.ColegioElectoral;
 import es.uniovi.asw.model.Voter;
 

--- a/VotingSystem/src/test/java/es/uniovi/asw/Voters/typesTests/UserPassTest.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/Voters/typesTests/UserPassTest.java
@@ -1,7 +1,7 @@
 /**
  * 
  */
-package es.uniovi.asw.voters.typestests;
+package es.uniovi.asw.Voters.typesTests;
 
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -14,8 +14,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import es.uniovi.asw.Application;
-import es.uniovi.asw.voters.types.Encrypter;
-import es.uniovi.asw.voters.types.UserPass;
+import es.uniovi.asw.Voters.types.Encrypter;
+import es.uniovi.asw.Voters.types.UserPass;
 
 /**
  * @author Amir H Tofigh H

--- a/VotingSystem/src/test/java/es/uniovi/asw/Voters/voterAccess/MainControllerTest.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/Voters/voterAccess/MainControllerTest.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.voters.voteraccess;
+package es.uniovi.asw.Voters.voterAccess;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;

--- a/VotingSystem/src/test/java/es/uniovi/asw/VotingSystem/CucumberTest.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/VotingSystem/CucumberTest.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.votingsystem;
+package es.uniovi.asw.VotingSystem;
 
 import org.junit.runner.RunWith;
 

--- a/VotingSystem/src/test/java/es/uniovi/asw/VotingSystem/FunctionalTest.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/VotingSystem/FunctionalTest.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.votingsystem;
+package es.uniovi.asw.VotingSystem;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -20,19 +20,20 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.util.Assert;
 import org.springframework.web.context.WebApplicationContext;
+
 import es.uniovi.asw.Application;
-import es.uniovi.asw.votingSystem.view.registerVote.pollingStationPresidentManagement.AddPV;
-import es.uniovi.asw.votingSystem.view.systemConfiguration.administratorManagement.ConfCand;
-import es.uniovi.asw.votingSystem.view.systemConfiguration.administratorManagement.ConfVT;
-import es.uniovi.asw.votingSystem.view.systemConfiguration.administratorManagement.GetCand;
-import es.uniovi.asw.votingSystem.view.systemConfiguration.administratorManagement.GetVT;
-import es.uniovi.asw.votingSystem.view.votingSystem.voterManagement.AlreadyV;
-import es.uniovi.asw.votingSystem.view.votingSystem.voterManagement.GetAV;
-import es.uniovi.asw.votingSystem.view.votingSystem.voterManagement.GetVO;
-import es.uniovi.asw.dbmanagement.CandidacyRepository;
-import es.uniovi.asw.dbmanagement.ConfirmedVoteRepository;
-import es.uniovi.asw.dbmanagement.VoterRepository;
-import es.uniovi.asw.dbmanagement.VotingRepository;
+import es.uniovi.asw.VotingSystem.view.registerVote.pollingStationPresidentManagement.AddPV;
+import es.uniovi.asw.VotingSystem.view.systemConfiguration.administratorManagement.ConfCand;
+import es.uniovi.asw.VotingSystem.view.systemConfiguration.administratorManagement.ConfVT;
+import es.uniovi.asw.VotingSystem.view.systemConfiguration.administratorManagement.GetCand;
+import es.uniovi.asw.VotingSystem.view.systemConfiguration.administratorManagement.GetVT;
+import es.uniovi.asw.VotingSystem.view.votingSystem.voterManagement.AlreadyV;
+import es.uniovi.asw.VotingSystem.view.votingSystem.voterManagement.GetAV;
+import es.uniovi.asw.VotingSystem.view.votingSystem.voterManagement.GetVO;
+import es.uniovi.asw.dbManagement.CandidacyRepository;
+import es.uniovi.asw.dbManagement.ConfirmedVoteRepository;
+import es.uniovi.asw.dbManagement.VoterRepository;
+import es.uniovi.asw.dbManagement.VotingRepository;
 import es.uniovi.asw.model.Candidatura;
 import es.uniovi.asw.model.Eleccion;
 import es.uniovi.asw.model.Voter;

--- a/VotingSystem/src/test/java/es/uniovi/asw/VotingSystem/MainControllerTest.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/VotingSystem/MainControllerTest.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.votingsystem;
+package es.uniovi.asw.VotingSystem;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;

--- a/VotingSystem/src/test/java/es/uniovi/asw/VotingSystem/ModelTest.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/VotingSystem/ModelTest.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.votingsystem;
+package es.uniovi.asw.VotingSystem;
 
 import static org.junit.Assert.assertEquals;
 

--- a/VotingSystem/src/test/java/es/uniovi/asw/VotingSystem/steps/AgregarElecciones.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/VotingSystem/steps/AgregarElecciones.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.votingsystem.steps;
+package es.uniovi.asw.VotingSystem.steps;
 
 import static org.junit.Assert.assertEquals;
 

--- a/VotingSystem/src/test/java/es/uniovi/asw/VotingSystem/steps/ConfigurarColegio.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/VotingSystem/steps/ConfigurarColegio.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.votingsystem.steps;
+package es.uniovi.asw.VotingSystem.steps;
 
 import static org.junit.Assert.assertEquals;
 

--- a/VotingSystem/src/test/java/es/uniovi/asw/VotingSystem/steps/ConsultarCandidaturas.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/VotingSystem/steps/ConsultarCandidaturas.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.votingsystem.steps;
+package es.uniovi.asw.VotingSystem.steps;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/VotingSystem/src/test/java/es/uniovi/asw/VotingSystem/steps/EmitirVoto.java
+++ b/VotingSystem/src/test/java/es/uniovi/asw/VotingSystem/steps/EmitirVoto.java
@@ -1,4 +1,4 @@
-package es.uniovi.asw.votingsystem.steps;
+package es.uniovi.asw.VotingSystem.steps;
 
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
Reverts Arquisoft/Voting_3a#46

Da problemas porque para windows y osx el sistema de ficheros es insensible a mayúsculas y minúsculas, lo que provoca que no se ha modificado el nombre de las carpetas (paquetes) no coincidiendo con su especificación.